### PR TITLE
Add rrule.Set.String() and rrule.Set.Recurrences()

### DIFF
--- a/rruleset.go
+++ b/rruleset.go
@@ -3,7 +3,6 @@ package rrule
 import (
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -15,24 +14,19 @@ type Set struct {
 	exdate []time.Time
 }
 
-func (set *Set) String() string {
-	res := set.Recurrences()
-	return strings.Join(res, "\n")
-}
-
 func (set *Set) Recurrences() []string {
 	res := []string{}
-	for _, o := range set.rrule {
-		res = append(res, fmt.Sprintf("RRULE:%v", o.String()))
+	for _, item := range set.rrule {
+		res = append(res, fmt.Sprintf("RRULE:%s", item))
 	}
-	for _, o := range set.rdate {
-		res = append(res, fmt.Sprintf("RDATE:%v", o.Format(strformat)))
+	for _, item := range set.rdate {
+		res = append(res, fmt.Sprintf("RDATE:%s", timeToStr(item)))
 	}
-	for _, o := range set.exrule {
-		res = append(res, fmt.Sprintf("EXRULE:%v", o.String()))
+	for _, item := range set.exrule {
+		res = append(res, fmt.Sprintf("EXRULE:%s", item))
 	}
-	for _, o := range set.exdate {
-		res = append(res, fmt.Sprintf("EXDATE:%v", o.Format(strformat)))
+	for _, item := range set.exdate {
+		res = append(res, fmt.Sprintf("EXDATE:%s", timeToStr(item)))
 	}
 	return res
 }

--- a/rruleset.go
+++ b/rruleset.go
@@ -14,7 +14,8 @@ type Set struct {
 	exdate []time.Time
 }
 
-func (set *Set) Recurrences() []string {
+// Recurrence returns a slice of all the recurrence rules for a set
+func (set *Set) Recurrence() []string {
 	res := []string{}
 	for _, item := range set.rrule {
 		res = append(res, fmt.Sprintf("RRULE:%s", item))

--- a/rruleset.go
+++ b/rruleset.go
@@ -1,7 +1,9 @@
 package rrule
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -11,6 +13,23 @@ type Set struct {
 	rdate  []time.Time
 	exrule []*RRule
 	exdate []time.Time
+}
+
+func (set *Set) String() string {
+	res := []string{}
+	for _, o := range set.rrule {
+		res = append(res, fmt.Sprintf("RRULE:%v", o.String()))
+	}
+	for _, o := range set.rdate {
+		res = append(res, fmt.Sprintf("RDATE:%v", o.Format(strformat)))
+	}
+	for _, o := range set.exrule {
+		res = append(res, fmt.Sprintf("EXRULE:%v", o.String()))
+	}
+	for _, o := range set.exdate {
+		res = append(res, fmt.Sprintf("EXDATE:%v", o.Format(strformat)))
+	}
+	return strings.Join(res, "\n")
 }
 
 // RRule include the given rrule instance in the recurrence set generation.

--- a/rruleset.go
+++ b/rruleset.go
@@ -16,6 +16,11 @@ type Set struct {
 }
 
 func (set *Set) String() string {
+	res := set.Recurrences()
+	return strings.Join(res, "\n")
+}
+
+func (set *Set) Recurrences() []string {
 	res := []string{}
 	for _, o := range set.rrule {
 		res = append(res, fmt.Sprintf("RRULE:%v", o.String()))
@@ -29,7 +34,7 @@ func (set *Set) String() string {
 	for _, o := range set.exdate {
 		res = append(res, fmt.Sprintf("EXDATE:%v", o.Format(strformat)))
 	}
-	return strings.Join(res, "\n")
+	return res
 }
 
 // RRule include the given rrule instance in the recurrence set generation.

--- a/rruleset_test.go
+++ b/rruleset_test.go
@@ -22,6 +22,33 @@ func TestSet(t *testing.T) {
 	}
 }
 
+func TestSetString(t *testing.T) {
+	set := Set{}
+	r, _ := NewRRule(ROption{Freq: YEARLY, Count: 1, Byweekday: []Weekday{TU},
+		Dtstart: time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC)})
+	set.RRule(r)
+	r, _ = NewRRule(ROption{Freq: YEARLY, Count: 3, Byweekday: []Weekday{TH},
+		Dtstart: time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC)})
+	set.ExRule(r)
+	set.ExDate(time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC))
+	set.ExDate(time.Date(1997, 9, 11, 9, 0, 0, 0, time.UTC))
+	set.ExDate(time.Date(1997, 9, 18, 9, 0, 0, 0, time.UTC))
+	set.RDate(time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC))
+	set.RDate(time.Date(1997, 9, 9, 9, 0, 0, 0, time.UTC))
+
+	want := `RRULE:FREQ=YEARLY;DTSTART=19970902T090000Z;COUNT=1;BYDAY=TU
+RDATE:19970904T090000Z
+RDATE:19970909T090000Z
+EXRULE:FREQ=YEARLY;DTSTART=19970902T090000Z;COUNT=3;BYDAY=TH
+EXDATE:19970904T090000Z
+EXDATE:19970911T090000Z
+EXDATE:19970918T090000Z`
+	value := set.String()
+	if want != value {
+		t.Errorf("get %v, want %v", value, want)
+	}
+}
+
 func TestSetDate(t *testing.T) {
 	set := Set{}
 	r, _ := NewRRule(ROption{Freq: YEARLY, Count: 1, Byweekday: []Weekday{TU},

--- a/rruleset_test.go
+++ b/rruleset_test.go
@@ -49,6 +49,21 @@ EXDATE:19970918T090000Z`
 	}
 }
 
+func TestSetRecurrences(t *testing.T) {
+	set := Set{}
+	r, _ := NewRRule(ROption{Freq: YEARLY, Count: 1, Byweekday: []Weekday{TU},
+		Dtstart: time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC)})
+	set.RRule(r)
+	value := set.Recurrences()
+	if len(value) != 1 {
+		t.Errorf("Wrong length for recurrence got=%v want=%v", len(value), 1)
+	}
+	want := "RRULE:FREQ=YEARLY;DTSTART=19970902T090000Z;COUNT=1;BYDAY=TU"
+	if value[0] != want {
+		t.Errorf("get %v, want %v", value[0], want)
+	}
+}
+
 func TestSetDate(t *testing.T) {
 	set := Set{}
 	r, _ := NewRRule(ROption{Freq: YEARLY, Count: 1, Byweekday: []Weekday{TU},

--- a/rruleset_test.go
+++ b/rruleset_test.go
@@ -49,12 +49,12 @@ EXDATE:19970918T090000Z`
 	}
 }
 
-func TestSetRecurrences(t *testing.T) {
+func TestSetRecurrence(t *testing.T) {
 	set := Set{}
 	r, _ := NewRRule(ROption{Freq: YEARLY, Count: 1, Byweekday: []Weekday{TU},
 		Dtstart: time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC)})
 	set.RRule(r)
-	value := set.Recurrences()
+	value := set.Recurrence()
 	if len(value) != 1 {
 		t.Errorf("Wrong length for recurrence got=%v want=%v", len(value), 1)
 	}

--- a/str.go
+++ b/str.go
@@ -204,6 +204,11 @@ func (r *RRule) String() string {
 	return r.OrigOptions.String()
 }
 
+func (set *Set) String() string {
+	res := set.Recurrences()
+	return strings.Join(res, "\n")
+}
+
 // StrToRRule converts string to RRule
 func StrToRRule(rfcString string) (*RRule, error) {
 	option, e := StrToROption(rfcString)

--- a/str.go
+++ b/str.go
@@ -205,7 +205,7 @@ func (r *RRule) String() string {
 }
 
 func (set *Set) String() string {
-	res := set.Recurrences()
+	res := set.Recurrence()
 	return strings.Join(res, "\n")
 }
 

--- a/str.go
+++ b/str.go
@@ -8,12 +8,16 @@ import (
 	"time"
 )
 
+const (
+	strformat = "20060102T150405Z"
+)
+
 func timeToStr(time time.Time) string {
-	return time.UTC().Format("20060102T150405Z")
+	return time.UTC().Format(strformat)
 }
 
 func strToTime(str string) (time.Time, error) {
-	return time.Parse("20060102T150405Z", str)
+	return time.Parse(strformat, str)
 }
 
 func (f Frequency) String() string {


### PR DESCRIPTION
These two methods allow for easier serialization of rrule sets. I've needed this in my applications for storing recurrences to the database and passing it between services. It seems like others have also needed this as well (see https://github.com/teambition/rrule-go/issues/6).