### PR TITLE
Add absent RRuleSet getters (GetRDate(), ...), extract StrSliceToRRuleSet() and StrToDates() functions

### DIFF
--- a/rruleset.go
+++ b/rruleset.go
@@ -47,6 +47,11 @@ func (set *Set) RDate(rdate time.Time) {
 	set.rdate = append(set.rdate, rdate)
 }
 
+// GetRDate returns explicitly added dates (rdates) in the set
+func (set *Set) GetRDate() []time.Time {
+	return set.rdate
+}
+
 // ExRule include the given rrule instance in the recurrence set exclusion list.
 // Dates which are part of the given recurrence rules will not be generated,
 // even if some inclusive rrule or rdate matches them.
@@ -54,11 +59,21 @@ func (set *Set) ExRule(exrule *RRule) {
 	set.exrule = append(set.exrule, exrule)
 }
 
+// GetExRule returns exclusion rrules list from in the set
+func (set *Set) GetExRule() []*RRule {
+	return set.exrule
+}
+
 // ExDate include the given datetime instance in the recurrence set exclusion list.
 // Dates included that way will not be generated,
 // even if some inclusive rrule or rdate matches them.
 func (set *Set) ExDate(exdate time.Time) {
 	set.exdate = append(set.exdate, exdate)
+}
+
+// GetExDate returns explicitly excluded dates (exdates) in the set
+func (set *Set) GetExDate() []time.Time {
+	return set.exdate
 }
 
 type genItem struct {

--- a/str.go
+++ b/str.go
@@ -9,15 +9,16 @@ import (
 )
 
 const (
-	strformat = "20060102T150405Z"
+	// DateTimeFormat is date-time format used in iCalendar (RFC 5545)
+	DateTimeFormat = "20060102T150405Z"
 )
 
 func timeToStr(time time.Time) string {
-	return time.UTC().Format(strformat)
+	return time.UTC().Format(DateTimeFormat)
 }
 
 func strToTime(str string) (time.Time, error) {
-	return time.Parse(strformat, str)
+	return time.Parse(DateTimeFormat, str)
 }
 
 func (f Frequency) String() string {

--- a/str.go
+++ b/str.go
@@ -220,13 +220,19 @@ func StrToRRule(rfcString string) (*RRule, error) {
 
 // StrToRRuleSet converts string to RRuleSet
 func StrToRRuleSet(s string) (*Set, error) {
-	s = strings.TrimSpace(strings.ToUpper(s))
+	s = strings.TrimSpace(s)
 	if s == "" {
 		return nil, errors.New("empty string")
 	}
+	ss := strings.Split(s, "\n")
+	return StrSliceToRRuleSet(ss)
+}
+
+// StrSliceToRRuleSet converts given str slice to RRuleSet
+func StrSliceToRRuleSet(ss []string) (*Set, error) {
 	set := Set{}
-	for _, line := range strings.Split(s, "\n") {
-		line = strings.TrimSpace(line)
+	for _, line := range ss {
+		line = strings.ToUpper(strings.TrimSpace(line))
 		if line == "" {
 			continue
 		}

--- a/str_test.go
+++ b/str_test.go
@@ -1,6 +1,8 @@
 package rrule
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestStr(t *testing.T) {
 	str := "FREQ=WEEKLY;DTSTART=20120201T093000Z;INTERVAL=5;WKST=TU;COUNT=2;UNTIL=20130130T230000Z;BYSETPOS=2;BYMONTH=3;BYYEARDAY=95;BYWEEKNO=1;BYDAY=MO,+2FR;BYHOUR=9;BYMINUTE=30;BYSECOND=0;BYEASTER=-1"
@@ -26,5 +28,57 @@ func TestInvalidString(t *testing.T) {
 		if _, e := StrToRRule(item); e == nil {
 			t.Errorf("StrToRRule(%q) = nil, want error", item)
 		}
+	}
+}
+
+func TestSetStr(t *testing.T) {
+	setStr := "RRULE:FREQ=DAILY;UNTIL=20180517T235959Z\n" +
+		"RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU\n" +
+		"EXRULE:FREQ=WEEKLY;INTERVAL=4;BYDAY=MO\n" +
+		"EXDATE;VALUE=DATE-TIME:20180525T070000Z,20180530T130000Z\n" +
+		"RDATE;VALUE=DATE-TIME:20180801T131313Z,20180902T141414Z\n"
+
+	set, err := StrToRRuleSet(setStr)
+	if err != nil {
+		t.Fatalf("StrToRRuleSet(%s) returned error: %v", setStr, err)
+	}
+
+	// matching parsed RRules
+	rRules := set.GetRRule()
+	if len(rRules) != 2 {
+		t.Errorf("Unexpected number of rrule parsed: %v != 2, rrules: %v", len(rRules), rRules)
+	}
+	if rRules[0].String() != "FREQ=DAILY;UNTIL=20180517T235959Z" {
+		t.Errorf("Unexpected rrule: %s", rRules[0].String())
+	}
+	if rRules[1].String() != "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU" {
+		t.Errorf("Unexpected rrule: %s", rRules[0].String())
+	}
+
+	// matching parsed EXRules
+	exRules := set.GetExRule()
+	if len(exRules) != 1 {
+		t.Errorf("Unexpected number of exrule parsed: %v != 1, exrules: %v", len(exRules), exRules)
+	}
+	if exRules[0].String() != "FREQ=WEEKLY;INTERVAL=4;BYDAY=MO" {
+		t.Errorf("Unexpected exrule: %s", exRules[0].String())
+	}
+
+	// matching parsed EXDates
+	exDates := set.GetExDate()
+	if len(exDates) != 2 {
+		t.Errorf("Unexpected number of exDates: %v != 2, %v", len(exDates), exDates)
+	}
+	if [2]string{timeToStr(exDates[0]), timeToStr(exDates[1])} != [2]string{"20180525T070000Z", "20180530T130000Z"} {
+		t.Errorf("Unexpected exDates: %v", exDates)
+	}
+
+	// matching parsed RDates
+	rDates := set.GetRDate()
+	if len(rDates) != 2 {
+		t.Errorf("Unexpected number of rDates: %v != 2, %v", len(rDates), rDates)
+	}
+	if [2]string{timeToStr(rDates[0]), timeToStr(rDates[1])} != [2]string{"20180801T131313Z", "20180902T141414Z"} {
+		t.Errorf("Unexpected exDates: %v", exDates)
 	}
 }


### PR DESCRIPTION
1. `GetRDate()` and other getters for rrule Set seem to be useful when working with rrule Set after parsing it from string
2. `StrSliceToRRuleSet()` takes array of strings, each encoding one RRULE, EXDATE, and so on. This one may be useful when not single string encoding rrule Set is passed to application, but array of strings as it is done when using Google Calendar API
3. `StrToDates()` added and made exported so that user may implement it's own logic during rrule Set construction and decide which parsed from string EXDATE/RDATE should be included in the set and which should not
4. Also I've made date-time format string exported too so that package user may rely on it somehow
5. Also simple test were added on parsing rrule set from string