### PR TITLE
Fix wrong behaviour due to time comparison with '==' operator

### DIFF
--- a/rruleset.go
+++ b/rruleset.go
@@ -123,7 +123,7 @@ func (set *Set) Iterator() (next func() (time.Time, bool)) {
 				rlist = rlist[1:]
 			}
 			sort.Sort(genItemSlice(rlist))
-			if lastdt.IsZero() || lastdt != dt {
+			if lastdt.IsZero() || !lastdt.Equal(dt) {
 				for len(exlist) != 0 && exlist[0].dt.Before(dt) {
 					exlist[0].dt, ok = exlist[0].gen()
 					if !ok {
@@ -132,7 +132,7 @@ func (set *Set) Iterator() (next func() (time.Time, bool)) {
 					sort.Sort(genItemSlice(exlist))
 				}
 				lastdt = dt
-				if len(exlist) == 0 || dt != exlist[0].dt {
+				if len(exlist) == 0 || !dt.Equal(exlist[0].dt) {
 					return dt, true
 				}
 			}

--- a/rruleset_test.go
+++ b/rruleset_test.go
@@ -245,3 +245,29 @@ func TestSetBetweenInc(t *testing.T) {
 		t.Errorf("get %v, want %v", value, want)
 	}
 }
+
+func TestSetTrickyTimeZones(t *testing.T) {
+	set := Set{}
+
+	moscow, _ := time.LoadLocation("Europe/Moscow")
+	newYork, _ := time.LoadLocation("America/New_York")
+	tehran, _ := time.LoadLocation("Asia/Tehran")
+
+	r, _ := NewRRule(ROption{
+		Freq:    DAILY,
+		Count:   4,
+		Dtstart: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).In(moscow),
+	})
+	set.RRule(r)
+
+	set.ExDate(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).In(newYork))
+	set.ExDate(time.Date(2000, 1, 2, 0, 0, 0, 0, time.UTC).In(tehran))
+	set.ExDate(time.Date(2000, 1, 3, 0, 0, 0, 0, time.UTC).In(moscow))
+	set.ExDate(time.Date(2000, 1, 4, 0, 0, 0, 0, time.UTC))
+
+	occurrences := set.All()
+
+	if len(occurrences) > 0 {
+		t.Errorf("No all occurrences excluded by ExDate: [%+v]", occurrences)
+	}
+}


### PR DESCRIPTION
See [doc](https://golang.org/pkg/time/#Time) for details why that is better to compare `time.Time` using `time.Equal()` method