### PR TITLE
Add RFC compatible DTSTART support

### DIFF
--- a/rrule.go
+++ b/rrule.go
@@ -104,6 +104,7 @@ type ROption struct {
 	Byminute   []int
 	Bysecond   []int
 	Byeaster   []int
+	RFC        bool
 }
 
 // RRule offers a small, complete, and very fast, implementation of the recurrence rules

--- a/rruleset.go
+++ b/rruleset.go
@@ -8,15 +8,20 @@ import (
 
 // Set allows more complex recurrence setups, mixing multiple rules, dates, exclusion rules, and exclusion dates
 type Set struct {
-	rrule  []*RRule
-	rdate  []time.Time
-	exrule []*RRule
-	exdate []time.Time
+	rrule   []*RRule
+	rdate   []time.Time
+	exrule  []*RRule
+	exdate  []time.Time
+	dtstart time.Time
 }
 
 // Recurrence returns a slice of all the recurrence rules for a set
 func (set *Set) Recurrence() []string {
-	res := []string{}
+	var res []string
+
+	if !set.dtstart.IsZero() {
+		res = append(res, fmt.Sprintf("DTSTART:%s", timeToDtStartStr(set.dtstart)))
+	}
 	for _, item := range set.rrule {
 		res = append(res, fmt.Sprintf("RRULE:%s", item))
 	}
@@ -30,6 +35,16 @@ func (set *Set) Recurrence() []string {
 		res = append(res, fmt.Sprintf("EXDATE:%s", timeToStr(item)))
 	}
 	return res
+}
+
+// DTStart sets dtstart property for all rules in set
+func (set *Set) DTStart(dtstart time.Time) {
+	set.dtstart = dtstart
+}
+
+// GetDTStart gets dtstart for set
+func (set *Set) GetDTStart() time.Time {
+	return set.dtstart
 }
 
 // RRule include the given rrule instance in the recurrence set generation.

--- a/rruleset_test.go
+++ b/rruleset_test.go
@@ -47,6 +47,49 @@ EXDATE:19970918T090000Z`
 	if want != value {
 		t.Errorf("get %v, want %v", value, want)
 	}
+
+	for _, rrule := range set.GetRRule() {
+		if rrule.OrigOptions.RFC {
+			t.Errorf("Expected rrule options to be RFC false, got true")
+		}
+	}
+}
+
+func TestSetRFCString(t *testing.T) {
+	set := Set{}
+	r, _ := NewRRule(ROption{Freq: YEARLY, Count: 1, Byweekday: []Weekday{TU}, RFC: true,
+		Dtstart: time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC)})
+	set.RRule(r)
+	r, _ = NewRRule(ROption{Freq: YEARLY, Count: 3, Byweekday: []Weekday{TH}, RFC: true,
+		Dtstart: time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC)})
+	set.ExRule(r)
+	set.ExDate(time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC))
+	set.ExDate(time.Date(1997, 9, 11, 9, 0, 0, 0, time.UTC))
+	set.ExDate(time.Date(1997, 9, 18, 9, 0, 0, 0, time.UTC))
+	set.RDate(time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC))
+	set.RDate(time.Date(1997, 9, 9, 9, 0, 0, 0, time.UTC))
+
+	nyLoc, _ := time.LoadLocation("America/New_York")
+	set.DTStart(time.Date(1997, 9, 2, 9, 0, 0, 0, nyLoc))
+
+	for _, rrule := range set.GetRRule() {
+		if !rrule.OrigOptions.RFC {
+			t.Errorf("Expected rrule options to be RFC true, got false")
+		}
+	}
+
+	want := `DTSTART:TZID=America/New_York:19970902T090000
+RRULE:FREQ=YEARLY;COUNT=1;BYDAY=TU
+RDATE:19970904T090000Z
+RDATE:19970909T090000Z
+EXRULE:FREQ=YEARLY;COUNT=3;BYDAY=TH
+EXDATE:19970904T090000Z
+EXDATE:19970911T090000Z
+EXDATE:19970918T090000Z`
+	value := set.String()
+	if want != value {
+		t.Errorf("get \n%v\n want \n%v\n", value, want)
+	}
 }
 
 func TestSetRecurrence(t *testing.T) {

--- a/str.go
+++ b/str.go
@@ -285,7 +285,7 @@ func StrSliceToRRuleSet(ss []string) (*Set, error) {
 			return nil, err
 		}
 
-		nameLen := strings.IndexAny(line, ";:")
+		nameLen := len(name)
 
 		switch name {
 		case "RRULE", "EXRULE":
@@ -360,13 +360,18 @@ func StrToDates(str string) (ts []time.Time, err error) {
 func processRRuleName(line string) (string, error) {
 	line = strings.ToUpper(strings.TrimSpace(line))
 	if line == "" {
-		return "", nil
-	}
-	nameLen := strings.IndexAny(line, ";:")
-	if nameLen < 0 {
 		return "", fmt.Errorf("bad format %v", line)
 	}
+
+	nameLen := strings.IndexAny(line, ";:")
+	if nameLen <= 0 {
+		return "", fmt.Errorf("bad format %v", line)
+	}
+
 	name := line[:nameLen]
+	if strings.IndexAny(name, "=") > 0 {
+		return "", fmt.Errorf("bad format %v", line)
+	}
 
 	return name, nil
 }
@@ -389,11 +394,8 @@ func strToDtStart(str string) (time.Time, error) {
 			return time.Time{}, fmt.Errorf("invalid timezone: %v", err.Error())
 		}
 		return strToTimeInLoc(tmp[1], loc)
-	}
-	if len(tmp) == 1 {
-		// no tzid
+	} else {
+		// no tzid, len == 1
 		return strToTime(tmp[0])
 	}
-
-	return time.Time{}, fmt.Errorf("impossible string")
 }

--- a/str_test.go
+++ b/str_test.go
@@ -59,6 +59,7 @@ func TestStr(t *testing.T) {
 func TestInvalidString(t *testing.T) {
 	cases := []string{
 		"",
+		"    ",
 		"FREQ",
 		"FREQ=HELLO",
 		"BYMONTH=",
@@ -107,7 +108,10 @@ func TestStrToDtStart(t *testing.T) {
 		"DTSTART:19970714T133000",
 		"DTSTART:19970714T133000Z",
 		"DTSTART;:19970714T133000Z",
+		"DTSTART;:1997:07:14T13:30:00Z",
 		";:19970714T133000Z",
+		"    ",
+		"",
 	}
 
 	for _, item := range validCases {
@@ -123,7 +127,78 @@ func TestStrToDtStart(t *testing.T) {
 	}
 }
 
+func TestStrToDates(t *testing.T) {
+	validCases := []string{
+		"19970714T133000",
+		"19970714T173000Z",
+		"VALUE=DATE-TIME:19970714T133000,19980714T133000,19980714T133000",
+	}
+
+	invalidCases := []string{
+		"VALUE:DATE:TIME:19970714T133000,19980714T133000,19980714T133000",
+		";:19970714T133000Z",
+		"    ",
+		"",
+	}
+
+	for _, item := range validCases {
+		if _, e := StrToDates(item); e != nil {
+			t.Errorf("StrToDates(%q) error = %s, want nil", item, e.Error())
+		}
+	}
+
+	for _, item := range invalidCases {
+		if _, e := StrToDates(item); e == nil {
+			t.Errorf("StrToDates(%q) err = nil, want not nil", item)
+		}
+	}
+}
+
+func TestProcessRRuleName(t *testing.T) {
+	validCases := []string{
+		"DTSTART;TZID=America/New_York:19970714T133000",
+		"RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU",
+		"EXRULE:FREQ=WEEKLY;INTERVAL=4;BYDAY=MO",
+		"EXDATE;VALUE=DATE-TIME:20180525T070000Z,20180530T130000Z",
+		"RDATE;VALUE=DATE-TIME:20180801T131313Z,20180902T141414Z",
+	}
+
+	invalidCases := []string{
+		"TZID=America/New_York:19970714T133000",
+		"19970714T1330000",
+		";:19970714T133000Z",
+		"FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU",
+		"    ",
+	}
+
+	for _, item := range validCases {
+		if _, e := processRRuleName(item); e != nil {
+			t.Errorf("processRRuleName(%q) error = %s, want nil", item, e.Error())
+		}
+	}
+
+	for _, item := range invalidCases {
+		if _, e := processRRuleName(item); e == nil {
+			t.Errorf("processRRuleName(%q) err = nil, want not nil", item)
+		}
+	}
+}
+
 func TestRFCSetStr(t *testing.T) {
+	badInputStrs := []string{
+		"",
+		"FREQ=DAILY;UNTIL=20180517T235959Z",
+		"DTSTART:;",
+		"RRULE:;",
+	}
+
+	for _, badInputStr := range badInputStrs {
+		_, err := StrToRRuleSet(badInputStr)
+		if err == nil {
+			t.Fatalf("StrToRRuleSet(%s) didn't return error", badInputStr)
+		}
+	}
+
 	inputStr := "DTSTART;TZID=America/New_York:20180101T090000\n" +
 		"RRULE:FREQ=DAILY;UNTIL=20180517T235959Z\n" +
 		"RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU\n" +


### PR DESCRIPTION
- Adds DTSTART support for reading and writing RRULES, and EXRULES including TZID
parameter for DTSTART
- Should be backwards compatible with non-compliant RRULES and EXRULES