### PR TITLE
Support TZID in EXDATE and RDATE rules

### DIFF
--- a/str.go
+++ b/str.go
@@ -345,10 +345,10 @@ func StrToDates(str string) (ts []time.Time, err error) {
 			if strings.HasPrefix(param, "TZID=") {
 				loc, err = parseTZID(param)
 			} else if param != "VALUE=DATE-TIME" {
-				err = fmt.Errorf("unsupported RDATE/EXDATE parm: %v", param)
+				err = fmt.Errorf("unsupported: %v", param)
 			}
 			if err != nil {
-				return
+				return nil, fmt.Errorf("bad dates param: %s", err.Error())
 			}
 		}
 		tmp = tmp[1:]

--- a/str.go
+++ b/str.go
@@ -329,25 +329,37 @@ func StrSliceToRRuleSet(ss []string) (*Set, error) {
 	return &set, nil
 }
 
-// StrToDates accepts string with format: "VALUE=DATE-TIME:{time},{time},...,{time}"
+// StrToDates is inteded to parse RDATE and EXDATE properties supporting only
+// VALUE=DATE-TIME (DATE and PERIOD are not supported).
+// Accepts string with format: "VALUE=DATE-TIME;[TZID=...]:{time},{time},...,{time}"
 // or simply "{time},{time},...{time}" and parses it to array of dates
-// may be used to parse RDATE/EXDATE rules
 func StrToDates(str string) (ts []time.Time, err error) {
 	tmp := strings.Split(str, ":")
 	if len(tmp) > 2 {
 		return nil, fmt.Errorf("bad format")
 	}
+	var loc *time.Location
 	if len(tmp) == 2 {
 		params := strings.Split(tmp[0], ";")
 		for _, param := range params {
-			if param != "VALUE=DATE-TIME" {
-				return nil, fmt.Errorf("unsupported RDATE/EXDATE parm: %v", param)
+			if strings.HasPrefix(param, "TZID=") {
+				loc, err = parseTZID(param)
+			} else if param != "VALUE=DATE-TIME" {
+				err = fmt.Errorf("unsupported RDATE/EXDATE parm: %v", param)
+			}
+			if err != nil {
+				return
 			}
 		}
 		tmp = tmp[1:]
 	}
 	for _, datestr := range strings.Split(tmp[0], ",") {
-		t, err := strToTime(datestr)
+		var t time.Time
+		if loc == nil {
+			t, err = strToTime(datestr)
+		} else {
+			t, err = strToTimeInLoc(datestr, loc)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("strToTime failed: %v", err)
 		}
@@ -383,19 +395,22 @@ func strToDtStart(str string) (time.Time, error) {
 	if len(tmp) > 2 || len(tmp) == 0 {
 		return time.Time{}, fmt.Errorf("bad format")
 	}
+
 	if len(tmp) == 2 {
 		// tzid
-		tzStr := strings.Split(tmp[0], "=")
-		if tzStr[0] != "TZID" || len(tzStr[1]) < 1 {
-			return time.Time{}, fmt.Errorf("bad parameter format")
-		}
-		loc, err := time.LoadLocation(tzStr[1])
+		loc, err := parseTZID(tmp[0])
 		if err != nil {
-			return time.Time{}, fmt.Errorf("invalid timezone: %v", err.Error())
+			return time.Time{}, err
 		}
 		return strToTimeInLoc(tmp[1], loc)
-	} else {
-		// no tzid, len == 1
-		return strToTime(tmp[0])
 	}
+	// no tzid, len == 1
+	return strToTime(tmp[0])
+}
+
+func parseTZID(s string) (*time.Location, error) {
+	if !strings.HasPrefix(s, "TZID=") || len(s) == len("TZID=") {
+		return nil, fmt.Errorf("bad TZID parameter format")
+	}
+	return time.LoadLocation(s[len("TZID="):])
 }

--- a/str_test.go
+++ b/str_test.go
@@ -132,6 +132,7 @@ func TestStrToDates(t *testing.T) {
 		"19970714T133000",
 		"19970714T173000Z",
 		"VALUE=DATE-TIME:19970714T133000,19980714T133000,19980714T133000",
+		"VALUE=DATE-TIME;TZID=America/New_York:19970714T133000,19980714T133000,19980714T133000",
 	}
 
 	invalidCases := []string{
@@ -139,6 +140,7 @@ func TestStrToDates(t *testing.T) {
 		";:19970714T133000Z",
 		"    ",
 		"",
+		"VALUE=DATE-TIME;TZID=:19970714T133000",
 	}
 
 	for _, item := range validCases {
@@ -154,13 +156,38 @@ func TestStrToDates(t *testing.T) {
 	}
 }
 
+func TestStrToDatesTimeIsCorrect(t *testing.T) {
+	nyLoc, _ := time.LoadLocation("America/New_York")
+	inputs := []string{
+		"VALUE=DATE-TIME:19970714T133000",
+		"VALUE=DATE-TIME;TZID=America/New_York:19970714T133000",
+	}
+	exp := []time.Time{
+		time.Date(1997, 7, 14, 13, 30, 0, 0, time.UTC),
+		time.Date(1997, 7, 14, 13, 30, 0, 0, nyLoc),
+	}
+
+	for i, s := range inputs {
+		ts, err := StrToDates(s)
+		if err != nil {
+			t.Fatalf("StrToDates(%s): error = %s", s, err.Error())
+		}
+		if len(ts) != 1 {
+			t.Fatalf("StrToDates(%s): bad answer: %v", s, ts)
+		}
+		if !ts[0].Equal(exp[i]) {
+			t.Fatalf("StrToDates(%s): bad answer: %v, expected: %v", s, ts[0], exp[i])
+		}
+	}
+}
+
 func TestProcessRRuleName(t *testing.T) {
 	validCases := []string{
 		"DTSTART;TZID=America/New_York:19970714T133000",
 		"RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU",
 		"EXRULE:FREQ=WEEKLY;INTERVAL=4;BYDAY=MO",
 		"EXDATE;VALUE=DATE-TIME:20180525T070000Z,20180530T130000Z",
-		"RDATE;VALUE=DATE-TIME:20180801T131313Z,20180902T141414Z",
+		"RDATE;TZID=America/New_York;VALUE=DATE-TIME:20180801T131313Z,20180902T141414Z",
 	}
 
 	invalidCases := []string{


### PR DESCRIPTION
As it is told in [RFC5545:3.2.19](https://tools.ietf.org/html/rfc5545#section-3.2.19), `TZID` parameter must be added to `EXDATE`/`RDATE` for them to specify times in a special time zone.

This PR simply adds such `TZID` parameter parsing to the `StrToDates` function.