### PR TITLE
Bugfix: Changing DTStart should recalculate the rule's internal timeset.

### DIFF
--- a/rrule.go
+++ b/rrule.go
@@ -212,16 +212,10 @@ func NewRRule(arg ROption) (*RRule, error) {
 	} else {
 		r.bysecond = arg.Bysecond
 	}
-	if r.freq < HOURLY {
-		for _, hour := range r.byhour {
-			for _, minute := range r.byminute {
-				for _, second := range r.bysecond {
-					r.timeset = append(r.timeset, time.Date(1, 1, 1, hour, minute, second, 0, r.dtstart.Location()))
-				}
-			}
-		}
-		sort.Sort(timeSlice(r.timeset))
-	}
+
+	// Calculate the timeset if needed
+	r.calculateTimeset()
+
 	return &r, nil
 }
 
@@ -786,4 +780,29 @@ func (r *RRule) Before(dt time.Time, inc bool) time.Time {
 // With inc == True, if dt itself is an occurrence, it will be returned.
 func (r *RRule) After(dt time.Time, inc bool) time.Time {
 	return after(r.Iterator(), dt, inc)
+}
+
+// DTStart set a new DTStart for the rule and recalculates the timeset if needed.
+func (r *RRule) DTStart(dt time.Time) {
+	r.dtstart = dt
+
+	// Calculate the timeset if needed
+	r.calculateTimeset()
+}
+
+// calculateTimeset calculates the timeset if needed.
+func (r *RRule) calculateTimeset() {
+	// Reset the timeset value
+	r.timeset = []time.Time{}
+
+	if r.freq < HOURLY {
+		for _, hour := range r.byhour {
+			for _, minute := range r.byminute {
+				for _, second := range r.bysecond {
+					r.timeset = append(r.timeset, time.Date(1, 1, 1, hour, minute, second, 0, r.dtstart.Location()))
+				}
+			}
+		}
+		sort.Sort(timeSlice(r.timeset))
+	}
 }

--- a/rruleset.go
+++ b/rruleset.go
@@ -42,7 +42,7 @@ func (set *Set) DTStart(dtstart time.Time) {
 	set.dtstart = dtstart
 
 	for _, r := range append(set.rrule, set.exrule...) {
-		r.dtstart = dtstart
+		r.DTStart(set.dtstart)
 	}
 }
 
@@ -52,7 +52,7 @@ func (set *Set) GetDTStart() time.Time {
 }
 
 // RRule include the given rrule instance in the recurrence set generation.
-func (set *Set) RRule(rrule *RRule) {	
+func (set *Set) RRule(rrule *RRule) {
 	set.rrule = append(set.rrule, rrule)
 }
 
@@ -74,7 +74,7 @@ func (set *Set) GetRDate() []time.Time {
 // ExRule include the given rrule instance in the recurrence set exclusion list.
 // Dates which are part of the given recurrence rules will not be generated,
 // even if some inclusive rrule or rdate matches them.
-func (set *Set) ExRule(exrule *RRule) {	
+func (set *Set) ExRule(exrule *RRule) {
 	set.exrule = append(set.exrule, exrule)
 }
 

--- a/rruleset_test.go
+++ b/rruleset_test.go
@@ -333,3 +333,47 @@ func TestSetDtStart(t *testing.T) {
 		}
 	}
 }
+
+func TestRuleSetChangeDTStartTimezoneRespected(t *testing.T) {
+	/*
+		https://golang.org/pkg/time/#LoadLocation
+
+		"The time zone database needed by LoadLocation may not be present on all systems, especially non-Unix systems.
+		LoadLocation looks in the directory or uncompressed zip file named by the ZONEINFO environment variable,
+		if any, then looks in known installation locations on Unix systems, and finally looks in
+		$GOROOT/lib/time/zoneinfo.zip."
+	*/
+	loc, err := time.LoadLocation("CET")
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	ruleSet := &Set{}
+	rule, err := NewRRule(
+		ROption{
+			Freq:     DAILY,
+			Count:    10,
+			Wkst:     MO,
+			Byhour:   []int{10},
+			Byminute: []int{0},
+			Bysecond: []int{0},
+			Dtstart:  time.Date(2019, 3, 6, 0, 0, 0, 0, loc),
+		},
+	)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+	ruleSet.RRule(rule)
+	ruleSet.DTStart(time.Date(2019, 3, 6, 0, 0, 0, 0, time.UTC))
+
+	events := ruleSet.All()
+	if len(events) != 10 {
+		t.Fatal("expected", 10, "got", len(events))
+	}
+
+	for _, e := range events {
+		if e.Location().String() != "UTC" {
+			t.Fatal("expected", "UTC", "got", e.Location().String())
+		}
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/teambition/rrule-go/issues/25.