### PR TITLE
Output DTSTART correctly for RFC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.test
 *.prof
 debug
+.idea

--- a/rruleset.go
+++ b/rruleset.go
@@ -20,7 +20,8 @@ func (set *Set) Recurrence() []string {
 	var res []string
 
 	if !set.dtstart.IsZero() {
-		res = append(res, fmt.Sprintf("DTSTART:%s", timeToDtStartStr(set.dtstart)))
+		// No colon, DTSTART may have TZID, which would require a semicolon after DTSTART
+		res = append(res, fmt.Sprintf("DTSTART%s", timeToDtStartStr(set.dtstart)))
 	}
 	for _, item := range set.rrule {
 		res = append(res, fmt.Sprintf("RRULE:%s", item))

--- a/rruleset_test.go
+++ b/rruleset_test.go
@@ -94,7 +94,7 @@ func TestSetRFCString(t *testing.T) {
 		}
 	}
 
-	want := `DTSTART:TZID=America/New_York:19970902T090000
+	want := `DTSTART;TZID=America/New_York:19970902T090000
 RRULE:FREQ=YEARLY;COUNT=1;BYDAY=TU
 RDATE:19970904T090000Z
 RDATE:19970909T090000Z
@@ -105,6 +105,14 @@ EXDATE:19970918T090000Z`
 	value := set.String()
 	if want != value {
 		t.Errorf("get \n%v\n want \n%v\n", value, want)
+	}
+
+	sset, err := StrToRRuleSet(set.String())
+	if err != nil {
+		t.Errorf("Could not create RSET from set output")
+	}
+	if sset.String() != set.String() {
+		t.Errorf("RSET created from set output different than original set")
 	}
 }
 

--- a/str.go
+++ b/str.go
@@ -22,7 +22,11 @@ func timeToStr(time time.Time) string {
 }
 
 func timeToDtStartStr(time time.Time) string {
-	return fmt.Sprintf("TZID=%s:%s", time.Location().String(), time.Format(LocalDateTimeFormat))
+	if time.Location().String() != "UTC" {
+		return fmt.Sprintf(";TZID=%s:%s", time.Location().String(), time.Format(LocalDateTimeFormat))
+	} else {
+		return fmt.Sprintf(":%s", time.Format(DateTimeFormat))
+	}
 }
 
 func strToTimeInLoc(str string, loc *time.Location) (time.Time, error) {

--- a/str_test.go
+++ b/str_test.go
@@ -1,6 +1,7 @@
 package rrule
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -34,7 +35,7 @@ func TestRFCSetToString(t *testing.T) {
 		t.Errorf("Expected RFC string FREQ=MONTHLY, got %v", r.String())
 	}
 
-	expectedSetStr := "DTSTART:TZID=America/New_York:20180101T090000\n" + "RRULE:FREQ=MONTHLY"
+	expectedSetStr := "DTSTART;TZID=America/New_York:20180101T090000\n" + "RRULE:FREQ=MONTHLY"
 
 	set := Set{}
 	set.RRule(r)
@@ -311,6 +312,42 @@ func TestSetParseLocalTimes(t *testing.T) {
 		d := s.GetRDate()[0]
 		if !d.Equal(time.Date(2018, 02, 23, 10, 0, 0, 0, moscow)) {
 			t.Error("Bad time parsed: ", d)
+		}
+	})
+
+	t.Run("DtstartTimeZoneValidOutput", func(t *testing.T) {
+		input := []string{
+			"DTSTART;TZID=Europe/Moscow:20180220T090000",
+			"RDATE;VALUE=DATE-TIME:20180223T100000",
+		}
+		expected := "DTSTART;TZID=Europe/Moscow:20180220T090000\nRDATE:20180223T070000Z"
+		s, err := StrSliceToRRuleSet(input)
+		if err != nil {
+			t.Error(err)
+		}
+
+		sRRule := s.String()
+
+		if sRRule != expected {
+			t.Error(fmt.Sprintf("DTSTART output not valid. Expected: \n%s \n Got: \n%s", expected, sRRule))
+		}
+	})
+
+	t.Run("DtstartUTCValidOutput", func(t *testing.T) {
+		input := []string{
+			"DTSTART:20180220T090000Z",
+			"RDATE;VALUE=DATE-TIME:20180223T100000",
+		}
+		expected := "DTSTART:20180220T090000Z\nRDATE:20180223T100000Z"
+		s, err := StrSliceToRRuleSet(input)
+		if err != nil {
+			t.Error(err)
+		}
+
+		sRRule := s.String()
+
+		if sRRule != expected {
+			t.Error(fmt.Sprintf("DTSTART output not valid. Expected: \n%s \n Got: \n%s", expected, sRRule))
 		}
 	})
 


### PR DESCRIPTION
- I was not outputting the RRULE correctly when RFC compatibility was
set for DTSTART. According to the spec there should be a semi-colon iff
there is a TZID attribute on the DTSTART key. Iff there is no TZID param
after the DTSTART key, there should be a colon, followed by the value of
the DTSTART key.

eg.

 DTSTART;TZID=America/New_York:20180101T090000 - correct
 DTSTART:20180101T090000Z - correct
 DTSTART:TZID=America/New_York:20180101T090000 - not correct

- This was causing issues passing the RRULE strings around between
different RRULE libraries (PHP/JS versions of RRULE libraries)