### PR TITLE
Validating parameters to RFC 5545

### DIFF
--- a/rrule.go
+++ b/rrule.go
@@ -234,7 +234,7 @@ func validateBounds(arg ROption) error {
 		bound []int
 		plusMinus bool // If the bound also applies for -x to -y.
 	} {
-		{arg.Bysecond, "bysecond", []int{0, 60}, false},
+		{arg.Bysecond, "bysecond", []int{0, 59}, false},
 		{arg.Byminute, "byminute", []int{0, 59}, false},
 		{arg.Byhour, "byhour", []int{0, 23}, false},
 		{arg.Bymonthday, "bymonthday", []int{1, 31}, true},

--- a/rrule_test.go
+++ b/rrule_test.go
@@ -65,6 +65,18 @@ func TestMonthlyMaxYear(t *testing.T) {
 	}
 }
 
+func TestWeeklyMaxYear(t *testing.T) {
+	// Purposefully doesn't match anything for code coverage.
+	r, _ := NewRRule(ROption{Freq: WEEKLY, Bymonthday: []int{31},
+		Byyearday: []int{1}, Dtstart: time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC),
+	})
+	value := r.All()
+	want := []time.Time{}
+	if !timesEqual(value, want) {
+		t.Errorf("get %v, want %v", value, want)
+	}
+}
+
 func TestInvalidRRules(t *testing.T) {
 	tests := []struct {
 		desc string
@@ -74,12 +86,12 @@ func TestInvalidRRules(t *testing.T) {
 		{
 			desc: "Bysecond under",
 			rrule: ROption{Freq: YEARLY, Bysecond: []int{-1}},
-			wantErr: "bysecond must be between 0 and 60",
+			wantErr: "bysecond must be between 0 and 59",
 		},
 		{
 			desc: "Bysecond over",
-			rrule: ROption{Freq: YEARLY, Bysecond: []int{61}},
-			wantErr: "bysecond must be between 0 and 60",
+			rrule: ROption{Freq: YEARLY, Bysecond: []int{60}},
+			wantErr: "bysecond must be between 0 and 59",
 		},
 		{
 			desc: "Byminute under",

--- a/rrule_test.go
+++ b/rrule_test.go
@@ -65,14 +65,136 @@ func TestMonthlyMaxYear(t *testing.T) {
 	}
 }
 
-func TestWeeklyMaxYear(t *testing.T) {
-	r, _ := NewRRule(ROption{Freq: WEEKLY, Bymonthday: []int{32},
-		Dtstart: time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC),
-	})
-	value := r.All()
-	want := []time.Time{}
-	if !timesEqual(value, want) {
-		t.Errorf("get %v, want %v", value, want)
+func TestInvalidRRules(t *testing.T) {
+	tests := []struct {
+		desc string
+		rrule ROption
+		wantErr string
+	} {
+		{
+			desc: "Bysecond under",
+			rrule: ROption{Freq: YEARLY, Bysecond: []int{-1}},
+			wantErr: "bysecond must be between 0 and 60",
+		},
+		{
+			desc: "Bysecond over",
+			rrule: ROption{Freq: YEARLY, Bysecond: []int{61}},
+			wantErr: "bysecond must be between 0 and 60",
+		},
+		{
+			desc: "Byminute under",
+			rrule: ROption{Freq: YEARLY, Byminute: []int{-1}},
+			wantErr: "byminute must be between 0 and 59",
+		},
+		{
+			desc: "Byminute over",
+			rrule: ROption{Freq: YEARLY, Byminute: []int{60}},
+			wantErr: "byminute must be between 0 and 59",
+		},
+		{
+			desc: "Byhour under",
+			rrule: ROption{Freq: YEARLY, Byhour: []int{-1}},
+			wantErr: "byhour must be between 0 and 23",
+		},
+		{
+			desc: "Byhour over",
+			rrule: ROption{Freq: YEARLY, Byhour: []int{24}},
+			wantErr: "byhour must be between 0 and 23",
+		},
+		{
+			desc: "Bymonthday under",
+			rrule: ROption{Freq: YEARLY, Bymonthday: []int{0}},
+			wantErr: "bymonthday must be between 1 and 31 or -1 and -31",
+		},
+		{
+			desc: "Bymonthday over",
+			rrule: ROption{Freq: YEARLY, Bymonthday: []int{32}},
+			wantErr: "bymonthday must be between 1 and 31 or -1 and -31",
+		},
+		{
+			desc: "Bymonthday under negative",
+			rrule: ROption{Freq: YEARLY, Bymonthday: []int{-32}},
+			wantErr: "bymonthday must be between 1 and 31 or -1 and -31",
+		},
+		{
+			desc: "Byyearday under",
+			rrule: ROption{Freq: YEARLY, Byyearday: []int{0}},
+			wantErr: "byyearday must be between 1 and 366 or -1 and -366",
+		},
+		{
+			desc: "Byyearday over",
+			rrule: ROption{Freq: YEARLY, Byyearday: []int{367}},
+			wantErr: "byyearday must be between 1 and 366 or -1 and -366",
+		},
+		{
+			desc: "Byyearday under negative",
+			rrule: ROption{Freq: YEARLY, Byyearday: []int{-367}},
+			wantErr: "byyearday must be between 1 and 366 or -1 and -366",
+		},
+		{
+			desc: "Byweekno under",
+			rrule: ROption{Freq: YEARLY, Byweekno: []int{0}},
+			wantErr: "byweekno must be between 1 and 53 or -1 and -53",
+		},
+		{
+			desc: "Byweekno over",
+			rrule: ROption{Freq: YEARLY, Byweekno: []int{54}},
+			wantErr: "byweekno must be between 1 and 53 or -1 and -53",
+		},
+		{
+			desc: "Byweekno under negative",
+			rrule: ROption{Freq: YEARLY, Byweekno: []int{-54}},
+			wantErr: "byweekno must be between 1 and 53 or -1 and -53",
+		},
+		{
+			desc: "Bymonth under",
+			rrule: ROption{Freq: YEARLY, Bymonth: []int{0}},
+			wantErr: "bymonth must be between 1 and 12",
+		},
+		{
+			desc: "Bymonth over",
+			rrule: ROption{Freq: YEARLY, Bymonth: []int{13}},
+			wantErr: "bymonth must be between 1 and 12",
+		},
+		{
+			desc: "Bysetpos under",
+			rrule: ROption{Freq: YEARLY, Bysetpos: []int{0}},
+			wantErr: "bysetpos must be between 1 and 366 or -1 and -366",
+		},
+		{
+			desc: "Bysetpos over",
+			rrule: ROption{Freq: YEARLY, Bysetpos: []int{367}},
+			wantErr: "bysetpos must be between 1 and 366 or -1 and -366",
+		},
+		{
+			desc: "Bysetpos under negative",
+			rrule: ROption{Freq: YEARLY, Bysetpos: []int{-367}},
+			wantErr: "bysetpos must be between 1 and 366 or -1 and -366",
+		},
+		{
+			desc: "Byday under",
+			rrule: ROption{Freq: YEARLY, Byweekday: []Weekday{{1, -54}}},
+			wantErr: "byday must be between 1 and 53 or -1 and -53",
+		},
+		{
+			desc: "Byday over",
+			rrule: ROption{Freq: YEARLY, Byweekday: []Weekday{{1, 54}}},
+			wantErr: "byday must be between 1 and 53 or -1 and -53",
+		},
+		{
+			desc: "Interval under",
+			rrule: ROption{Freq: DAILY, Interval: -1},
+			wantErr: "interval must be greater than 0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := NewRRule(tc.rrule)
+			if err == nil || err.Error() != tc.wantErr {
+				t.Errorf("got %q, want %q", err, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/str.go
+++ b/str.go
@@ -174,6 +174,7 @@ func StrToROptionInLocation(rfcString string, loc *time.Location) (*ROption, err
 	}
 	result := ROption{}
 	result.RFC = true
+	freqSet := false
 	for _, attr := range strings.Split(rfcString, ";") {
 		keyValue := strings.Split(attr, "=")
 		if len(keyValue) != 2 {
@@ -187,6 +188,7 @@ func StrToROptionInLocation(rfcString string, loc *time.Location) (*ROption, err
 		switch key {
 		case "FREQ":
 			result.Freq, e = strToFreq(value)
+			freqSet = true
 		case "DTSTART":
 			result.RFC = false
 			result.Dtstart, e = strToTimeInLoc(value, loc)
@@ -224,6 +226,13 @@ func StrToROptionInLocation(rfcString string, loc *time.Location) (*ROption, err
 		if e != nil {
 			return nil, e
 		}
+	}
+	if !freqSet {
+		// Per RFC 5545, FREQ is mandatory and supposed to be the first
+		// parameter. We'll just confirm it exists because we do not
+		// have a meaningful default nor a way to confirm if we parsed
+		// a value from the options this returns.
+		return nil, errors.New("RRULE property FREQ is required")
 	}
 	return &result, nil
 }

--- a/str_test.go
+++ b/str_test.go
@@ -69,6 +69,7 @@ func TestInvalidString(t *testing.T) {
 		"FREQ=WEEKLY;BYDAY=M",
 		"FREQ=WEEKLY;BYDAY=MQ",
 		"FREQ=WEEKLY;BYDAY=+MO",
+		"BYDAY=MO",
 	}
 	for _, item := range cases {
 		if _, e := StrToRRule(item); e == nil {


### PR DESCRIPTION
Per the RFC, many fields have limits that were not being checked (except
Bysetpos, for whatever reason). This can result in user error not being caught
early and also prevents you from using this library to catch said errors.

As well, FREQ is required by the RFC and if it wasn't specified, we would badly
assume some default. For these bounds in the standard, see:
https://tools.ietf.org/html/rfc5545#section-3.3.10

Note: it turns out we don't handle leap seconds right (they're why seconds go to
60 and not 59). In fact, when I tried to write a test with `BYSECOND=60`, it
was an infinite loop. Not sure if the bounds should be restricted below the RFC
as a result (I mean, who would honestly use leap seconds in a RRule, anyway?).