### PR TITLE
Add RDate and ExDate setters

### DIFF
--- a/rruleset.go
+++ b/rruleset.go
@@ -74,6 +74,11 @@ func (set *Set) RDate(rdate time.Time) {
 	set.rdate = append(set.rdate, rdate)
 }
 
+// SetRDates sets explicitly added dates (rdates) in the set
+func (set *Set) SetRDates(rdates []time.Time) {
+	set.rdate = rdates
+}
+
 // GetRDate returns explicitly added dates (rdates) in the set
 func (set *Set) GetRDate() []time.Time {
 	return set.rdate
@@ -99,6 +104,11 @@ func (set *Set) GetExRule() []*RRule {
 // even if some inclusive rrule or rdate matches them.
 func (set *Set) ExDate(exdate time.Time) {
 	set.exdate = append(set.exdate, exdate)
+}
+
+// SetExDates sets explicitly excluded dates (exdates) in the set
+func (set *Set) SetExDates(exdates []time.Time) {
+	set.exdate = exdates
 }
 
 // GetExDate returns explicitly excluded dates (exdates) in the set

--- a/rruleset_test.go
+++ b/rruleset_test.go
@@ -147,6 +147,26 @@ func TestSetDate(t *testing.T) {
 	}
 }
 
+func TestSetRDates(t *testing.T) {
+	set := Set{}
+	r, _ := NewRRule(ROption{Freq: YEARLY, Count: 1, Byweekday: []Weekday{TU},
+		Dtstart: time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC)})
+	set.RRule(r)
+	set.SetRDates([]time.Time{
+		time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC),
+		time.Date(1997, 9, 9, 9, 0, 0, 0, time.UTC),
+	})
+	value := set.All()
+	want := []time.Time{
+		time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC),
+		time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC),
+		time.Date(1997, 9, 9, 9, 0, 0, 0, time.UTC),
+	}
+	if !timesEqual(value, want) {
+		t.Errorf("get %v, want %v", value, want)
+	}
+}
+
 func TestSetExRule(t *testing.T) {
 	set := Set{}
 	r, _ := NewRRule(ROption{Freq: YEARLY, Count: 6, Byweekday: []Weekday{TU, TH},
@@ -172,6 +192,25 @@ func TestSetExDate(t *testing.T) {
 	set.ExDate(time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC))
 	set.ExDate(time.Date(1997, 9, 11, 9, 0, 0, 0, time.UTC))
 	set.ExDate(time.Date(1997, 9, 18, 9, 0, 0, 0, time.UTC))
+	value := set.All()
+	want := []time.Time{time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC),
+		time.Date(1997, 9, 9, 9, 0, 0, 0, time.UTC),
+		time.Date(1997, 9, 16, 9, 0, 0, 0, time.UTC)}
+	if !timesEqual(value, want) {
+		t.Errorf("get %v, want %v", value, want)
+	}
+}
+
+func TestSetExDates(t *testing.T) {
+	set := Set{}
+	r, _ := NewRRule(ROption{Freq: YEARLY, Count: 6, Byweekday: []Weekday{TU, TH},
+		Dtstart: time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC)})
+	set.RRule(r)
+	set.SetExDates([]time.Time{
+		time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC),
+		time.Date(1997, 9, 11, 9, 0, 0, 0, time.UTC),
+		time.Date(1997, 9, 18, 9, 0, 0, 0, time.UTC),
+	})
 	value := set.All()
 	want := []time.Time{time.Date(1997, 9, 2, 9, 0, 0, 0, time.UTC),
 		time.Date(1997, 9, 9, 9, 0, 0, 0, time.UTC),


### PR DESCRIPTION
Currently, we can only use `RDate(time.Time)` and `ExDate(time.Time)` to append the new date. 

Added `SetRDates([]time.Time)` and `SetExDates([]time.Time)` setter for RDate and ExDate to set the entire RDates and ExDates after parsing it from string. 