### PR TITLE
Honor TZID when evaluating UNTIL [Issue 37]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/teambition/rrule-go
 
 go 1.12
+
+require github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/rruleset_test.go
+++ b/rruleset_test.go
@@ -1,6 +1,8 @@
 package rrule
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
@@ -439,4 +441,11 @@ func TestRuleSetChangeDTStartTimezoneRespected(t *testing.T) {
 			t.Fatal("expected", "UTC", "got", e.Location().String())
 		}
 	}
+}
+
+func TestStrToRRuleSetWithUntilForRecurrence(t *testing.T) {
+	str := "DTSTART;TZID=America/Los_Angeles:20200225T060000\nRRULE:FREQ=WEEKLY;INTERVAL=1;WKST=MO;BYDAY=TU;UNTIL=20200303T063000"
+	r, err := StrToRRuleSet(str)
+	require.NoError(t, err, "should successfully parse the RRULE")
+	assert.Equal(t, 2, len(r.All()), "should find two recurrences and treat UNTIL in specified TIMEZONE")
 }

--- a/str.go
+++ b/str.go
@@ -309,7 +309,7 @@ func StrSliceToRRuleSetInLoc(ss []string, defaultLoc *time.Location) (*Set, erro
 
 		switch name {
 		case "RRULE", "EXRULE":
-			rOpt, err := StrToROption(rule)
+			rOpt, err := StrToROptionInLocation(rule, defaultLoc)
 			if err != nil {
 				return nil, fmt.Errorf("StrToROption failed: %v", err)
 			}

--- a/str_test.go
+++ b/str_test.go
@@ -91,7 +91,7 @@ func TestSetStr(t *testing.T) {
 		t.Fatalf("StrToRRuleSet(%s) returned error: %v", setStr, err)
 	}
 
-	assertRulesMatch(set, t)
+	assertRulesMatch(set, t, false)
 }
 
 func TestStrToDtStart(t *testing.T) {
@@ -281,7 +281,7 @@ func TestRFCSetStr(t *testing.T) {
 		t.Errorf("dtstart time wrong should be %s but is %s", dtWantTime, dtstart)
 	}
 
-	assertRulesMatch(set, t)
+	assertRulesMatch(set, t, true)
 
 	dtWantAfter := time.Date(2018, 1, 2, 9, 0, 0, 0, nyLoc)
 	dtAfter := set.After(dtWantTime, false)
@@ -405,7 +405,7 @@ func TestStrSetParseErrors(t *testing.T) {
 }
 
 // Helper for TestRFCSetStr and TestSetStr
-func assertRulesMatch(set *Set, t *testing.T) {
+func assertRulesMatch(set *Set, t *testing.T, withLocale bool) {
 	// matching parsed RRules
 	rRules := set.GetRRule()
 	if len(rRules) != 3 {
@@ -417,7 +417,13 @@ func assertRulesMatch(set *Set, t *testing.T) {
 	if rRules[1].String() != "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU" {
 		t.Errorf("Unexpected rrule: %s", rRules[0].String())
 	}
-	if rRules[2].String() != "FREQ=MONTHLY;UNTIL=20180520T000000Z;BYMONTHDAY=1,2,3" {
+
+	expectedRRule3 := "FREQ=MONTHLY;UNTIL=20180520T000000Z;BYMONTHDAY=1,2,3"
+	if withLocale {
+		expectedRRule3 = "FREQ=MONTHLY;UNTIL=20180520T040000Z;BYMONTHDAY=1,2,3"
+	}
+
+	if rRules[2].String() != expectedRRule3 {
 		t.Errorf("Unexpected rrule: %s", rRules[2].String())
 	}
 


### PR DESCRIPTION
Issue: https://github.com/teambition/rrule-go/issues/37

Easy fix where I call `StrToROptionInLocation` with defaultLoc instead of just `StrToROption` that defaults to UTC.

```
		case "RRULE", "EXRULE":
			rOpt, err := StrToROptionInLocation(rule, defaultLoc)
			if err != nil {
				return nil, fmt.Errorf("StrToROption failed: %v", err)
			}
```

Other notable changelog:
- Updated TestStrSet and TestRFCSet so that the UNTIL now respects UTC or NY timezone
- Added a testcase and imported `assert` and `require` library. I'm ok with rejecting this added testcase.