### PR TITLE
enable serialization of non-UTC EXDATE & RDATE

### DIFF
--- a/rruleset.go
+++ b/rruleset.go
@@ -28,11 +28,11 @@ func (set *Set) Recurrence() []string {
 	}
 
 	for _, item := range set.rdate {
-		res = append(res, fmt.Sprintf("RDATE:%s", timeToStr(item)))
+		res = append(res, fmt.Sprintf("RDATE%s", timeToRFCDatetimeStr(item)))
 	}
 
 	for _, item := range set.exdate {
-		res = append(res, fmt.Sprintf("EXDATE:%s", timeToStr(item)))
+		res = append(res, fmt.Sprintf("EXDATE%s", timeToRFCDatetimeStr(item)))
 	}
 	return res
 }

--- a/rruleset_test.go
+++ b/rruleset_test.go
@@ -30,23 +30,27 @@ func TestSetOverlapping(t *testing.T) {
 }
 
 func TestSetString(t *testing.T) {
+	moscow, _ := time.LoadLocation("Europe/Moscow")
+	newYork, _ := time.LoadLocation("America/New_York")
+	tehran, _ := time.LoadLocation("Asia/Tehran")
+
 	set := Set{}
 	r, _ := NewRRule(ROption{Freq: YEARLY, Count: 1, Byweekday: []Weekday{TU},
 		Dtstart: time.Date(1997, 9, 2, 8, 0, 0, 0, time.UTC)})
 	set.RRule(r)
 	set.ExDate(time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC))
-	set.ExDate(time.Date(1997, 9, 11, 9, 0, 0, 0, time.UTC))
-	set.ExDate(time.Date(1997, 9, 18, 9, 0, 0, 0, time.UTC))
-	set.RDate(time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC))
+	set.ExDate(time.Date(1997, 9, 11, 9, 0, 0, 0, time.UTC).In(moscow))
+	set.ExDate(time.Date(1997, 9, 18, 9, 0, 0, 0, time.UTC).In(newYork))
+	set.RDate(time.Date(1997, 9, 4, 9, 0, 0, 0, time.UTC).In(tehran))
 	set.RDate(time.Date(1997, 9, 9, 9, 0, 0, 0, time.UTC))
 
 	want := `DTSTART:19970902T080000Z
 RRULE:FREQ=YEARLY;COUNT=1;BYDAY=TU
-RDATE:19970904T090000Z
+RDATE;TZID=Asia/Tehran:19970904T133000
 RDATE:19970909T090000Z
 EXDATE:19970904T090000Z
-EXDATE:19970911T090000Z
-EXDATE:19970918T090000Z`
+EXDATE;TZID=Europe/Moscow:19970911T130000
+EXDATE;TZID=America/New_York:19970918T050000`
 	value := set.String()
 	if want != value {
 		t.Errorf("get %v, want %v", value, want)

--- a/str_test.go
+++ b/str_test.go
@@ -331,7 +331,7 @@ func TestSetParseLocalTimes(t *testing.T) {
 			"DTSTART;TZID=Europe/Moscow:20180220T090000",
 			"RDATE;VALUE=DATE-TIME:20180223T100000",
 		}
-		expected := "DTSTART;TZID=Europe/Moscow:20180220T090000\nRDATE:20180223T070000Z"
+		expected := "DTSTART;TZID=Europe/Moscow:20180220T090000\nRDATE;TZID=Europe/Moscow:20180223T100000"
 		s, err := StrSliceToRRuleSet(input)
 		if err != nil {
 			t.Error(err)
@@ -378,17 +378,34 @@ func TestSetParseLocalTimes(t *testing.T) {
 }
 
 func TestRDateValueDateStr(t *testing.T) {
-	input := []string{
-		"RDATE;VALUE=DATE:20180223",
-	}
-	s, err := StrSliceToRRuleSet(input)
-	if err != nil {
-		t.Error(err)
-	}
-	d := s.GetRDate()[0]
-	if !d.Equal(time.Date(2018, 02, 23, 0, 0, 0, 0, time.UTC)) {
-		t.Error("Bad time parsed: ", d)
-	}
+	t.Run("DefaultToUTC", func(t *testing.T) {
+		input := []string{
+			"RDATE;VALUE=DATE:20180223",
+		}
+		s, err := StrSliceToRRuleSet(input)
+		if err != nil {
+			t.Error(err)
+		}
+		d := s.GetRDate()[0]
+		if !d.Equal(time.Date(2018, 02, 23, 0, 0, 0, 0, time.UTC)) {
+			t.Error("Bad time parsed: ", d)
+		}
+	})
+
+	t.Run("PreserveExplicitTimezone", func(t *testing.T) {
+		denver, _ := time.LoadLocation("America/Denver")
+		input := []string{
+			"RDATE;VALUE=DATE;TZID=America/Denver:20180223",
+		}
+		s, err := StrSliceToRRuleSet(input)
+		if err != nil {
+			t.Error(err)
+		}
+		d := s.GetRDate()[0]
+		if !d.Equal(time.Date(2018, 02, 23, 0, 0, 0, 0, denver)) {
+			t.Error("Bad time parsed: ", d)
+		}
+	})
 }
 
 func TestStrSetEmptySliceParse(t *testing.T) {


### PR DESCRIPTION
This fixes two issues:

1) When a rule set was round tripped (parse -> serialize ->
parse -> generate) using a RRuleSet like:

DTSTART;TZID=America/Denver:20220401T000000
RRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20220607T060000Z;BYDAY=TU
RDATE;TZID=America/Denver:20220511T000000
EXDATE;TZID=America/Denver:20220510T000000

The generated timestamps would unexpectedly change timezone:

2022-04-12 00:00:00 -0600 MDT
2022-04-26 00:00:00 -0600 MDT
2022-05-11 06:00:00 +0000 UTC
2022-05-24 00:00:00 -0600 MDT

2) StrSliceToRRuleSet() deliberately assumes that "floating" local
times after a DTSTART should have the same timezone as the DTSTART.
But when the RRuleSet is serialized, the RDATE and EXDATE lines are
converted to UTC making this behavior less obvious.

While there is a small risk of change in behavior for existing
applications, a timezone database change (e.g. moving daylight
saving time) is required to produce obviously different results
because users are rarely exposed to raw timestamps.

If an application depends on the old, implicit conversion to UTC,
it can be updated to explicitly convert RDATE & EXDATE values itself.
The benefit is that applications that want the RDATE & EXDATE values
in a different timezone are now able to do so.